### PR TITLE
Fix rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,60 @@
+AllCops:
+  Include:
+    - ./**/*.rb
+
+# Configuration parameters: AllowURI, URISchemes.
+Metrics/LineLength:
+  Max: 328
+
+# 'Complexity' is very relative
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+# 'Complexity' is very relative
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+# 'Complexity' is very relative
+Metrics/AbcSize:
+  Enabled: false
+
+# Method length is not necessarily an indicator of code quality
+Metrics/MethodLength:
+  Enabled: false
+
+# Class length is not necessarily an indicator of code quality
+Metrics/ClassLength:
+  Enabled: false
+
+# dealbreaker:
+Style/TrailingComma:
+  Enabled: false
+Style/ClosingParenthesisIndentation:
+  Enabled: false
+
+# we still support ruby 1.8
+Style/HashSyntax:
+  Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+Style/RegexpLiteral:
+  Enabled: true
+Style/WordArray:
+  Enabled: true
+
+# this catches the cases of using `module` for parser functions, types, or
+# providers
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Description: 'Document classes and non-namespace modules.'
+  Enabled: false
+
+# More comfortable block layouts
+Style/BlockDelimiters:
+  Enabled: False
+
+Style/MultilineBlockLayout:
+  Enabled: False

--- a/sources/controllers/cache_option_controller.rb
+++ b/sources/controllers/cache_option_controller.rb
@@ -1,6 +1,6 @@
 namespace '/cache_options' do
   get do
-    return_resource object: CacheOption.all()
+    return_resource object: CacheOption.all
   end
 
   post do
@@ -22,7 +22,7 @@ namespace '/cache_options' do
     end
 
     get do
-     return_resource object: @cache_options
+      return_resource object: @cache_options
     end
   end
 end

--- a/sources/controllers/ceph_mon_node_controller.rb
+++ b/sources/controllers/ceph_mon_node_controller.rb
@@ -1,6 +1,6 @@
 namespace '/ceph_mon_nodes' do
   get do
-    return_resource object: CephMonNode.all()
+    return_resource object: CephMonNode.all
   end
 
   post do

--- a/sources/controllers/ceph_osd_node_controller.rb
+++ b/sources/controllers/ceph_osd_node_controller.rb
@@ -1,6 +1,6 @@
 namespace '/ceph_osd_nodes' do
   get do
-    return_resource object: CephOsdNode.all()
+    return_resource object: CephOsdNode.all
   end
 
   post do

--- a/sources/controllers/domain_controller.rb
+++ b/sources/controllers/domain_controller.rb
@@ -1,6 +1,6 @@
 namespace '/domains' do
   get do
-    return_resource object: Domain.all()
+    return_resource object: Domain.all
   end
 
   post do

--- a/sources/controllers/domain_state_controller.rb
+++ b/sources/controllers/domain_state_controller.rb
@@ -1,6 +1,6 @@
 namespace '/domain_states' do
   get do
-    return_resource object: DomainState.all()
+    return_resource object: DomainState.all
   end
 
   post do

--- a/sources/controllers/interface_controller.rb
+++ b/sources/controllers/interface_controller.rb
@@ -1,6 +1,6 @@
 namespace '/interfaces' do
   get do
-    return_resource object: Interface.all()
+    return_resource object: Interface.all
   end
 
   post do

--- a/sources/controllers/ipv4_controller.rb
+++ b/sources/controllers/ipv4_controller.rb
@@ -1,6 +1,6 @@
 namespace '/ipv4s' do
   get do
-    @ipv4s = Ipv4.all()
+    @ipv4s = Ipv4.all
     return_resource object: @ipv4s
   end
 
@@ -26,5 +26,4 @@ namespace '/ipv4s' do
       return_resource object: @ipv4
     end
   end
-
 end

--- a/sources/controllers/ipv6_controller.rb
+++ b/sources/controllers/ipv6_controller.rb
@@ -1,6 +1,6 @@
 namespace '/ipv6s' do
   get do
-    return_resource object: Ipv6.all()
+    return_resource object: Ipv6.all
   end
 
   post do

--- a/sources/controllers/node_method_controller.rb
+++ b/sources/controllers/node_method_controller.rb
@@ -1,6 +1,6 @@
 namespace '/node_methods' do
   get do
-    return_resource object: NodeMethod.all()
+    return_resource object: NodeMethod.all
   end
 
   post do

--- a/sources/controllers/node_state_controller.rb
+++ b/sources/controllers/node_state_controller.rb
@@ -1,6 +1,6 @@
 namespace '/node_states' do
   get do
-    return_resource object: NodeState.all()
+    return_resource object: NodeState.all
   end
 
   post do

--- a/sources/controllers/storage_controller.rb
+++ b/sources/controllers/storage_controller.rb
@@ -1,6 +1,6 @@
 namespace '/storages' do
   get do
-    return_resource object: Storage.all()
+    return_resource object: Storage.all
   end
 
   post do

--- a/sources/controllers/storage_type_controller.rb
+++ b/sources/controllers/storage_type_controller.rb
@@ -1,6 +1,6 @@
 namespace '/storage_types' do
   get do
-    return_resource object: StorageType.all()
+    return_resource object: StorageType.all
   end
 
   post do

--- a/sources/controllers/virt_method_controller.rb
+++ b/sources/controllers/virt_method_controller.rb
@@ -1,6 +1,6 @@
 namespace '/virt_methods' do
   get do
-    return_resource object: VirtMethod.all()
+    return_resource object: VirtMethod.all
   end
 
   post do

--- a/sources/controllers/virt_node_controller.rb
+++ b/sources/controllers/virt_node_controller.rb
@@ -1,6 +1,6 @@
 namespace '/virt_nodes' do
   get do
-    return_resource object: VirtNpde.all()
+    return_resource object: VirtNpde.all
   end
 
   post do

--- a/sources/controllers/vlan_controller.rb
+++ b/sources/controllers/vlan_controller.rb
@@ -1,6 +1,6 @@
 namespace '/vlans' do
   get do
-    return_resource object: Vlan.all()
+    return_resource object: Vlan.all
   end
 
   post do

--- a/sources/lib/generic_helper.rb
+++ b/sources/lib/generic_helper.rb
@@ -1,21 +1,19 @@
-def return_resource object: nil
-  if object
-    clazz = object.class.to_s
-    clazz = if clazz[/([\S]+)::/]
-              clazz = /([\S]+)::/.match(clazz)[1].pluralize
-            else
-              clazz
-            end.underscore
-    
-    respond_to do |type|
-      type.html do
-        haml clazz.to_sym
-      end
-      
-      type.json do
-        json clazz => object
-      end
-    
+def return_resource(object: nil)
+  return false unless object
+  clazz = object.class.to_s
+  clazz = if clazz[/([\S]+)::/]
+            clazz = /([\S]+)::/.match(clazz)[1].pluralize
+          else
+            clazz
+          end.underscore
+
+  respond_to do |type|
+    type.html do
+      haml clazz.to_sym
+    end
+
+    type.json do
+      json clazz => object
     end
   end
 end

--- a/sources/models/ceph_mon_node.rb
+++ b/sources/models/ceph_mon_node.rb
@@ -1,3 +1,2 @@
 class CephMonNode < Node
-
 end

--- a/sources/models/ceph_osd_node.rb
+++ b/sources/models/ceph_osd_node.rb
@@ -1,3 +1,2 @@
 class CephOsdNode < Node
-
 end

--- a/sources/models/domain.rb
+++ b/sources/models/domain.rb
@@ -1,5 +1,4 @@
 class Domain < ActiveRecord::Base
-
   has_many :interfaces
   has_many :ipv4s, through: :interfaces
   has_many :ipv6s, through: :interfaces

--- a/sources/models/domain_state.rb
+++ b/sources/models/domain_state.rb
@@ -1,3 +1,2 @@
 class DomainState < ActiveRecord::Base
-
 end

--- a/sources/models/interface.rb
+++ b/sources/models/interface.rb
@@ -1,5 +1,5 @@
 class Interface < ActiveRecord::Base
-  # todo: add validation to check that an interface is only owned by a VM OR node
+  # TODO: add validation to check that an interface is only owned by a domain OR node
   has_many :ipv4s
   has_many :ipv6s
   has_many :vlans

--- a/sources/models/ipv4.rb
+++ b/sources/models/ipv4.rb
@@ -1,5 +1,3 @@
 class Ipv4 < ActiveRecord::Base
-
   belongs_to :interface
-
 end

--- a/sources/models/ipv6.rb
+++ b/sources/models/ipv6.rb
@@ -1,5 +1,3 @@
 class Ipv6 < ActiveRecord::Base
-
   belongs_to :interface
-
 end

--- a/sources/models/node.rb
+++ b/sources/models/node.rb
@@ -1,9 +1,7 @@
 class Node < ActiveRecord::Base
-
   has_many :interfaces
   has_many :ipv4s, through: :interfaces
   has_many :ipv6s, through: :interfaces
   has_many :vlans, through: :interfaces
   belongs_to :node_state
-
 end

--- a/sources/models/node_method.rb
+++ b/sources/models/node_method.rb
@@ -1,8 +1,6 @@
 class NodeMethod < ActiveRecord::Base
-
   has_one :domain
 
   belongs_to :virt_method
   belongs_to :virt_node
-
 end

--- a/sources/models/node_state.rb
+++ b/sources/models/node_state.rb
@@ -1,4 +1,3 @@
 class NodeState < ActiveRecord::Base
-
   belongs_to :node
 end

--- a/sources/models/storage.rb
+++ b/sources/models/storage.rb
@@ -1,7 +1,5 @@
 class Storage < ActiveRecord::Base
-
   belongs_to :storage_type
   belongs_to :cache_option
   belongs_to :domain
-
 end

--- a/sources/models/virt_method.rb
+++ b/sources/models/virt_method.rb
@@ -1,6 +1,4 @@
 class VirtMethod < ActiveRecord::Base
-
   has_many :node_methods
   has_many :virt_nodes, through: :node_methods
-
 end

--- a/sources/models/virt_node.rb
+++ b/sources/models/virt_node.rb
@@ -1,7 +1,5 @@
 class VirtNode < Node
-
   has_many :node_methods
   has_many :virt_methods, through: :node_methods
   has_many :domains, through: :node_methods
-
 end

--- a/sources/models/vlan.rb
+++ b/sources/models/vlan.rb
@@ -1,5 +1,3 @@
 class Vlan < ActiveRecord::Base
-
   belongs_to :interface
-
 end

--- a/sources/puma.rb
+++ b/sources/puma.rb
@@ -1,10 +1,10 @@
-#environment 'production'
+# environment 'production'
 
 pidfile 'puma.pid'
 
-threads 0,1
+threads 0, 1
 workers 1
 
-#daemonize true
+# daemonize true
 
 bind 'tcp://127.0.0.1:4568'

--- a/sources/virtapi_app.rb
+++ b/sources/virtapi_app.rb
@@ -5,9 +5,10 @@ require 'haml'
 require 'json'
 require 'active_record'
 
-require_relative 'models/node.rb' #preload node model because of Dir.glob order fuckup
-                                  #TODO: define a hierarchy of models to load
+# preload node model because of Dir.glob order fuckup
+# TODO: define a hierarchy of models to load
 
+require_relative 'models/node.rb'
 Dir.glob('./{models,controllers,lib}/*.rb').each { |file| require file }
 
 @environment = ENV['RACK_ENV'] || 'development'
@@ -16,13 +17,13 @@ ActiveRecord::Base.logger = Logger.new(STDERR)
 ActiveRecord::Base.establish_connection @dbconfig[@environment]
 
 # manual style
-#ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: "#{__dir__}/dbfile.sqlite")
+# ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: "#{__dir__}/dbfile.sqlite")
 
 before /.*/ do
   if request.path_info.match(/.json$/)
     content_type :json, 'charset' => 'utf-8'
     request.accept.unshift('application/json')
-    request.path_info = request.path_info.gsub(/.json$/,'')
+    request.path_info = request.path_info.gsub(/.json$/, '')
   else
     content_type :html, 'charset' => 'utf-8'
   end


### PR DESCRIPTION
this fixes all but one rubocop issue. The missing one:

```
virtapi_app.rb:22:8: W: Ambiguous regexp literal. Parenthesize the method arguments if it's surely a regexp literal, or add a whitespace to the right of the / if it should be a division.
before /.*/ do
       ^

42 files inspected, 1 offense detected
```
