### PR TITLE
Feature composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 dbfile.sqlite
 puma.pid
 .bundle/
+.*.swp

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ gem 'haml'
 
 group :development do
   gem 'rubocop', require: false
+  gem 'pry', require: false
 end

--- a/database/migrations/006_initialize_virt.rb
+++ b/database/migrations/006_initialize_virt.rb
@@ -9,12 +9,13 @@ class InitializeVirt < ActiveRecord::Migration
 
     create_table :virt_nodes do |t|
       t.timestamps null: false
+      t.belongs_to :node, index: true
       t.integer :local_storage_gb
       t.string :vg_name
       t.string :local_storage_path
     end
 
-    create_table :node_method do |t|
+    create_table :node_methods do |t|
       t.timestamps null: false
       t.belongs_to :virt_node, index: true
       t.belongs_to :virt_method, index: true

--- a/database/schema.rb
+++ b/database/schema.rb
@@ -97,15 +97,15 @@ ActiveRecord::Schema.define(version: 6) do
   add_index "ipv6s", ["interface_id"], name: "index_ipv6s_on_interface_id"
   add_index "ipv6s", ["ip"], name: "index_ipv6s_on_ip", unique: true
 
-  create_table "node_method", force: :cascade do |t|
+  create_table "node_methods", force: :cascade do |t|
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.integer  "virt_node_id"
     t.integer  "virt_method_id"
   end
 
-  add_index "node_method", ["virt_method_id"], name: "index_node_method_on_virt_method_id"
-  add_index "node_method", ["virt_node_id"], name: "index_node_method_on_virt_node_id"
+  add_index "node_methods", ["virt_method_id"], name: "index_node_methods_on_virt_method_id"
+  add_index "node_methods", ["virt_node_id"], name: "index_node_methods_on_virt_node_id"
 
   create_table "node_states", force: :cascade do |t|
     t.datetime "created_at",  null: false
@@ -166,10 +166,13 @@ ActiveRecord::Schema.define(version: 6) do
   create_table "virt_nodes", force: :cascade do |t|
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
+    t.integer  "node_id"
     t.integer  "local_storage_gb"
     t.string   "vg_name"
     t.string   "local_storage_path"
   end
+
+  add_index "virt_nodes", ["node_id"], name: "index_virt_nodes_on_node_id"
 
   create_table "vlans", force: :cascade do |t|
     t.datetime "created_at",   null: false

--- a/models/ceph_mon_node.rb
+++ b/models/ceph_mon_node.rb
@@ -1,2 +1,3 @@
-class CephMonNode < Node
+class CephMonNode < ActiveRecord::Base
+  belongs_to :node
 end

--- a/models/ceph_osd_node.rb
+++ b/models/ceph_osd_node.rb
@@ -1,2 +1,3 @@
-class CephOsdNode < Node
+class CephOsdNode < ActiveRecord::Base
+  belongs_to :node
 end

--- a/models/node.rb
+++ b/models/node.rb
@@ -3,5 +3,8 @@ class Node < ActiveRecord::Base
   has_many :ipv4s, through: :interfaces
   has_many :ipv6s, through: :interfaces
   has_many :vlans, through: :interfaces
+  has_many :node_methods, through: :virt_node
+  has_many :virt_methods, through: :virt_node
+  has_many :domains, through: :virt_node
   belongs_to :node_state
 end

--- a/models/virt_node.rb
+++ b/models/virt_node.rb
@@ -1,5 +1,6 @@
-class VirtNode < Node
+class VirtNode < ActiveRecord::Base
   has_many :node_methods
   has_many :virt_methods, through: :node_methods
   has_many :domains, through: :node_methods
+  belongs_to :node
 end


### PR DESCRIPTION
as visible in our ERD, the three roles virt_node, ceph_osd_node and
ceph_mon_node are not hinherited from node, they compose the node. The
old implementation was based on inheritance, this commit fixes it.
- the roles inherit from ActiveRecord::Base as every model, not from node
- we defined the relation with belongs_to in the role models and their migrations
- updated the schema to the latest version
- fixed a typo in 006_initialize_virt.rb

updating existing schemas is a bad idea for stable software, however we
didn't hit 1.0.0 so far so this is okay.
