### PR TITLE
fix warnings in rubocop about wrong hash notation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,10 +32,6 @@ Metrics/ClassLength:
 Style/ClosingParenthesisIndentation:
   Enabled: false
 
-# we still support ruby 1.8
-Style/HashSyntax:
-  Enabled: false
-
 Lint/AmbiguousRegexpLiteral:
   Enabled: true
 Style/RegexpLiteral:

--- a/database/migrations/005_initialize_network.rb
+++ b/database/migrations/005_initialize_network.rb
@@ -8,28 +8,28 @@ class InitializeNetwork < ActiveRecord::Migration
       t.belongs_to :domain, index: true
       t.string :mac
     end
-    add_index :interfaces, :mac, :unique => true
+    add_index :interfaces, :mac, unique: true
 
     create_table :ipv6s do |t|
       t.timestamps null: false
       t.belongs_to :interface, index: true
       t.string :ip
     end
-    add_index :ipv6s, :ip, :unique => true
+    add_index :ipv6s, :ip, unique: true
 
     create_table :ipv4s do |t|
       t.timestamps null: false
       t.belongs_to :interface, index: true
       t.string :ip
     end
-    add_index :ipv4s, :ip, :unique => true
+    add_index :ipv4s, :ip, unique: true
 
     create_table :vlans do |t|
       t.timestamps null: false
       t.belongs_to :interface, index: true
       t.integer :tag
     end
-    add_index :vlans, :tag, :unique => true
+    add_index :vlans, :tag, unique: true
   end
 end
 


### PR DESCRIPTION
we remove the ruby1.8 support in rubocop and fix the notation(which was
in 1.8 style)
